### PR TITLE
Fix/cli disable

### DIFF
--- a/src/services.js
+++ b/src/services.js
@@ -24,15 +24,15 @@ const services = {
     const objs = _.filter(_.isType('object'), tasks)
     // If any running task doesn't have object config and no services specified in command line, keep all services
     if (objs.length !== tasks.length && !services.disabled.length && !services.disableAll) return cfg
-    const allSvcs = _.map(_.keys, cfg.services)
+    const allSvcs = _.chain(_.keys, cfg.services)
     let svcs
     if (services.disableAll) {
-      svcs = _.flatten(allSvcs)
+      svcs = allSvcs
     } else {
-      svcs = _.unique([
-        ...services.disabled,
-        ..._.chain(t => t.disable === '*' ? allSvcs : t.disable, objs)
-      ])
+      svcs = _.chain(t => t.disable === '*' ? allSvcs : t.disable, objs)
+      services.disabled.forEach(s => {
+        if (!_.contains(s, svcs)) svcs.push(s)
+      })
     }
     // Track which services are disabled by running tasks
     const counts = _.pipe([

--- a/test/src/services.spec.js
+++ b/test/src/services.spec.js
@@ -180,8 +180,20 @@ describe('services', () => {
         tasks: { test: { disable: '*', cmd: 'echo hello' }, lint: { disable: ['shared'], cmd: 'lint' } },
         run: ['test', 'lint']
       }
+      // testing -d arg for config-disabled service
+      services.disabled = [ 'shared' ]
       expect(services.filterEnabled(cfg).services).to.deep.equal([{ onlyTest: { from: 'onlyTest' } }])
       expect(services.disabled[0]).to.equal('shared')
+    })
+    it('disables services via command line and task config', () => {
+      const cfg = {
+        services: [{ keep: { from: 'test' } }, { configSvc: { from: 'configSvc' } }, { cliSvc: { from: 'cliSvc' } }],
+        tasks: { test: { disable: ['configSvc'], cmd: 'echo hello' } },
+        run: ['test']
+      }
+      services.disabled = [ 'cliSvc' ]
+      expect(services.filterEnabled(cfg).services).to.deep.equal([{ keep: { from: 'test' } }])
+      expect(services.disabled).to.deep.equal([ 'configSvc', 'cliSvc' ])
     })
   })
 })


### PR DESCRIPTION
No ticket. Fixes bug that occurs when trying to disable a service via the command line that's already disabled in the task config.