### PR TITLE
Feat/disable all

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ binci lint -d mongo
 or all services:
 
 ```
+binci lint -d '*'
 binci lint --disable-all
 ```
 

--- a/src/args.js
+++ b/src/args.js
@@ -55,6 +55,7 @@ const args = {
    */
   disable: () => {
     services.disabled = Array.isArray(args.raw.d) ? _.unique(args.raw.d) : [ args.raw.d ]
+    if (_.contains('*', services.disabled)) args.disableAll()
   },
   /**
    * Marks all services to be disabled

--- a/test/src/args.spec.js
+++ b/test/src/args.spec.js
@@ -51,6 +51,13 @@ describe('args', () => {
       args.disable()
       expect(services.disabled).to.deep.equal([ 'foo' ])
     })
+    it('calls disableAll if * is passed as arg', () => {
+      sandbox.spy(args, 'disableAll')
+      args.raw = { d: '*' }
+      args.disable()
+      expect(args.disableAll).to.be.calledOnce()
+      expect(services.disableAll).to.be.true()
+    })
   })
   describe('disableAll', () => {
     it('sets services.disableAll to true', () => {


### PR DESCRIPTION
No ticket. Adds support for disabling all services via `binci <task> -d '*'`, in addition to the existing `--disable-all`.