### PR TITLE
refactor(cleanup): match format in orphan warning and cleanup

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -87,7 +87,7 @@ const utils = {
     const orphans = utils.parseOrphans(ps)
     if (orphans.length) {
       output.line()
-      output.warn(`These containers may not have exited correctly: ${orphans.join(', ')}`)
+      output.warn(`These containers may not have exited correctly: \n- ${orphans.join('\n- ')}`)
       output.warn('You can attempt to remove these by running `binci --cleanup`')
       output.line()
     }

--- a/src/utils.js
+++ b/src/utils.js
@@ -32,7 +32,7 @@ const utils = {
    * @returns {object} promise
    */
   cleanup: (all = false) => Promise.resolve().then(() => {
-    const findCmd = all ? 'docker ps -q' : 'docker ps --filter="name=bc_" -q'
+    const findCmd = all ? 'docker ps --format "{{.Names}}"' : 'docker ps --filter="name=bc_" --format "{{.Names}}"'
     const ids = cp.execSync(findCmd)
       .toString()
       .split(/\r?\n/)

--- a/test/src/utils.spec.js
+++ b/test/src/utils.spec.js
@@ -98,7 +98,7 @@ describe('utils', () => {
       sandbox.stub(proc, 'exec', () => Promise.resolve(fixtures.ps.full))
       return utils.checkOrphans().then(() => {
         expect(output.warn).to.be.calledWith(
-          'These containers may not have exited correctly: bc_orphan3_JKLod93dS, bc_orphan4_MNJ9ie00d')
+          'These containers may not have exited correctly: \n- bc_orphan3_JKLod93dS\n- bc_orphan4_MNJ9ie00d')
       })
     })
   })


### PR DESCRIPTION
Closes #78.

Now instead of being comma separated, orphaned containers are separated by new lines like:
```
⚠ These containers may not have exited correctly:
- bc_elasticsearch_B1tRKhcEW
- bc_ftp_B1tRKhcEW
⚠ You can attempt to remove these by running `binci --cleanup`
```
And the `cleanup` output lists the container names instead of their ids:
```
Stopping 6 containers:
✔ bc_elasticmq_SJ5Q9354-
✔ bc_aws-dynamodb_SJ5Q9354-
✔ bc_mysql_SJ5Q9354-
✔ bc_postgres_SJ5Q9354-
✔ bc_elasticsearch_SJ5Q9354-
✔ bc_ftp_SJ5Q9354-
```