### PR TITLE
feat(env): do not convert undefined environment values to the string "null"

### DIFF
--- a/src/command.js
+++ b/src/command.js
@@ -19,7 +19,7 @@ const command = {
    * @returns {String}
    */
   parseHostEnvVars: (str) => str.toString().replace(/\$\{([^}]+)\}/g, (i, match) => {
-    const [envVar, defaultValue = null] = match.split(':-')
+    const [envVar, defaultValue = ''] = match.split(':-')
     return process.env.hasOwnProperty(envVar) ? process.env[envVar] : defaultValue
   }),
   /**

--- a/test/src/command.spec.js
+++ b/test/src/command.spec.js
@@ -13,8 +13,8 @@ describe('command', () => {
     it('supports bash-style default values for environment variables', () => {
       expect(command.parseHostEnvVars('test-${NOT_DEFINED:-myValue}')).to.equal('test-myValue') // eslint-disable-line no-template-curly-in-string
     })
-    it('parses a string and returns with null replace if no host environment variables found', () => {
-      expect(command.parseHostEnvVars('test-${BC_TEST_EV_DNE}')).to.equal('test-null') // eslint-disable-line no-template-curly-in-string
+    it('parses a string and returns with an empty string replace for unset host environment variables', () => {
+      expect(command.parseHostEnvVars('test-${BC_TEST_EV_DNE}')).to.equal('test-') // eslint-disable-line no-template-curly-in-string
     })
   })
   describe('parseArgs', () => {


### PR DESCRIPTION
Currently, if an environment variable is not set, binci will convert it to the string literal `null` before passing it into the container. This can cause issues with the default shell behavior, since it would be expected to be an empty string (and therefore falsey) but instead the `null` string literal causes it to be treated as truthy. Example:

## Before
```
env:
   - FOO=${UNSET_ENV_VAR}
```

```sh
echo ${FOO:-defaultValue} # null
```

## After
```
env:
   - FOO=${UNSET_ENV_VAR}
```

```sh
echo ${FOO:-defaultValue} # defaultValue
```