### PR TITLE
docs(README): Remove binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ to setup and maintain these environments manually.
 
 ### YARN/NPM
 
+The best way to install Binci and keep it updated is through NPM, included with [Node.js](https://nodejs.org) or Yarn.
+
 `yarn global add binci` or `npm install binci -g`
 
 ---

--- a/README.md
+++ b/README.md
@@ -23,29 +23,6 @@ to setup and maintain these environments manually.
 
 `yarn global add binci` or `npm install binci -g`
 
-**Note: Binci requires Node v.6+ to run.**
-
-### Binaries
-
-**Linux [(download)](http://binci.technologyadvice.com/linux/binci)**
-
-```
-curl -o /usr/local/bin/binci http://binci.technologyadvice.com/linux/binci && \
-chmod +x /usr/local/bin/binci
-```
-
-**Mac OSX [(download)](http://binci.technologyadvice.com/mac/binci)**
-
-```
-sudo mkdir -p /usr/local/bin && \
-sudo curl -o /usr/local/bin/binci http://binci.technologyadvice.com/mac/binci && \
-sudo chmod +x /usr/local/bin/binci
-```
-
-**Windows [(download)](http://binci.technologyadvice.com/windows/binci.exe)**
-
-Download the above file and run from the path where it is saved or add to a directory in your `PATH`.
-
 ---
 
 *Obvious Note: You need to have [Docker](https://www.docker.com/) installed as well.*

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ to setup and maintain these environments manually.
 
 ### YARN/NPM
 
-The best way to install Binci and keep it updated is through NPM, included with [Node.js](https://nodejs.org) or Yarn.
+The best way to install Binci and keep it updated is through NPM, included with [Node.js](https://nodejs.org), or Yarn.
 
 `yarn global add binci` or `npm install binci -g`
 


### PR DESCRIPTION
Neither Kent nor I can get `pkg` to compile this thing anymore, and the old binary locations aren't accessible anymore. Let's remove the option to avoid confusion until we solve it.