### PR TITLE
fix(command): Do not run with -it if not on a TTY

### DIFF
--- a/src/command.js
+++ b/src/command.js
@@ -106,7 +106,11 @@ const command = {
     const cwd = process.cwd()
     const serviceArgs = cfg.rmOnShutdown ? ['run', '-d', '--privileged'] : ['run', '-d', '--rm', '--privileged']
     const workDir = cfg.workDir || cwd
-    let args = primary ? ['run', '--rm', '-it', '-v', `${cwd}:${workDir}`, '-v', `${tmpdir}:${tmpdir}`, '-w', workDir, '--privileged'] : serviceArgs
+    /* istanbul ignore next */
+    const itFlags = process.stdout.isTTY ? '-it' : ''
+    let args = primary
+      ? ['run', '--rm', itFlags, '-v', `${cwd}:${workDir}`, '-v', `${tmpdir}:${tmpdir}`, '-w', workDir, '--privileged']
+      : serviceArgs
     args = args.concat(_.flatten([
       command.getArgs(cfg),
       command.getLinks(cfg),

--- a/test/fixtures/instance.js
+++ b/test/fixtures/instance.js
@@ -8,8 +8,8 @@ const instance = {
         args: [
           'run',
           '-d',
-          '--rm',
           '--privileged',
+          '--rm',
           '-p',
           '27017:27017',
           '--name',
@@ -22,7 +22,6 @@ const instance = {
       args: [
         'run',
         '--rm',
-        '-it',
         '-v',
         '/tmp:/tmp',
         '-v',
@@ -30,6 +29,7 @@ const instance = {
         '-w',
         '/tmp',
         '--privileged',
+        '-it',
         '-p',
         '8080:8080',
         '--link',
@@ -52,8 +52,8 @@ const instance = {
         args: [
           'run',
           '-d',
-          '--rm',
           '--privileged',
+          '--rm',
           '-p',
           '27017:27017',
           '--name',
@@ -66,7 +66,6 @@ const instance = {
       args: [
         'run',
         '--rm',
-        '-it',
         '-v',
         '/tmp:/tmp',
         '-v',
@@ -74,6 +73,7 @@ const instance = {
         '-w',
         '/tmp',
         '--privileged',
+        '-it',
         '-p',
         '8080:8080',
         '--link',

--- a/test/src/command.spec.js
+++ b/test/src/command.spec.js
@@ -89,14 +89,14 @@ describe('command', () => {
     it('returns array of arguments for a service config', () => {
       process.env.BN_TEST_EV = 'foo'
       const actual = command.get({ from: 'mongo', env: ['BN_TEST_EV=${BN_TEST_EV}'], expose: ['8080:8080', '9090:9090'] }, 'mongo') // eslint-disable-line no-template-curly-in-string
-      expect(actual).to.deep.equal(['run', '-d', '--rm', '--privileged', '-e', 'BN_TEST_EV=foo', '-p', '8080:8080', '-p', '9090:9090', '--name', 'bc_mongo_test', 'mongo'])
+      expect(actual).to.deep.equal(['run', '-d', '--privileged', '--rm', '-e', 'BN_TEST_EV=foo', '-p', '8080:8080', '-p', '9090:9090', '--name', 'bc_mongo_test', 'mongo'])
       delete process.env.BN_TEST_EV
     })
     it('returns object with array of arguments and command for a primary container config', () => {
       process.env.BN_TEST_EV = 'foo'
       const actual = command.get({ from: 'mongo', env: ['BN_TEST_EV=${BN_TEST_EV}'], expose: ['8080:8080'], run: ['foo'], tasks: { foo: 'echo "foo"' } }, 'primary', '/tmp', true) // eslint-disable-line no-template-curly-in-string
       expect(actual).to.deep.equal({
-        args: ['run', '--rm', '-it', '-v', '/tmp:/tmp', '-v', '/tmp:/tmp', '-w', '/tmp', '--privileged', '-e', 'BN_TEST_EV=foo', '-p', '8080:8080', '--name', 'bc_primary_test', 'mongo', 'sh', '/tmp/binci.sh'],
+        args: ['run', '--rm', '-v', '/tmp:/tmp', '-v', '/tmp:/tmp', '-w', '/tmp', '--privileged', '-it', '-e', 'BN_TEST_EV=foo', '-p', '8080:8080', '--name', 'bc_primary_test', 'mongo', 'sh', '/tmp/binci.sh'],
         cmd: '#!/bin/sh\nset -e;\necho "foo"'
       })
       delete process.env.BN_TEST_EV

--- a/test/src/services.spec.js
+++ b/test/src/services.spec.js
@@ -34,7 +34,7 @@ describe('services', () => {
     it('returns an array of services and their command arrays', () => {
       const svc = services.get(_.merge({ rmOnShutdown: false }, config.load()))
       expect(svc[0].name).to.equal('mongodb')
-      expect(svc[0].args).to.deep.equal(['run', '-d', '--rm', '--privileged', '-p', '27017:27017', '--name', 'bc_mongodb_test', 'mongo:3.0'])
+      expect(svc[0].args).to.deep.equal(['run', '-d', '--privileged', '--rm', '-p', '27017:27017', '--name', 'bc_mongodb_test', 'mongo:3.0'])
     })
     it('returns an array of services and their command arrays (with rmOnShutdown)', () => {
       const svc = services.get(_.merge({ rmOnShutdown: true }, config.load()))


### PR DESCRIPTION
A TTY is not provided on some CI test runners (notably, AWS CodeBuild), and results in Binci failing to run with the message `the input device is not a TTY`. This change only connects the TTY if stdout itself is a TTY.

(Note: still testing this change)