### PR TITLE
Tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,17 @@ For testing different images easily, the either the `-b <build-dockerfile>` or `
 
 If a `dockerfile` is being used rather than the `from` property, `tags` can be specified to define one or more tags to apply to any newly built container in addition to the default Binci tag. They can be specified in any format accepted by the `docker build` command's `-t` flag, such as `repo/imageName:version`. 
 
+```yaml
+dockerfile: ./Dockerfile
+tags:
+  - myorg/myrepo:latest
+  - myorg/myrepo:5.1.0
+```
+
+The above binci.yml will, in the event that Binci needs to build a new container, tag the build with Binci's own tag in
+addition to the two listed tags. When Binci is done running, the command `docker push myorg/myrepo:latest` would work
+as expected.
+
 ## Services
 
 Services add links into the primary container, exposing the services for utilization. For the most part, services utilize the same format for definition as the primary container.

--- a/README.md
+++ b/README.md
@@ -111,6 +111,10 @@ The `from` configuration property causes Binci to use the specified image to run
 
 For testing different images easily, the either the `-b <build-dockerfile>` or `-f <from-alternate-image>` arguments can be passed on execution.
 
+## Tags (`tags <Array<string>>`)
+
+If a `dockerfile` is being used rather than the `from` property, `tags` can be specified to define one or more tags to apply to any newly built container in addition to the default Binci tag. They can be specified in any format accepted by the `docker build` command's `-t` flag, such as `repo/imageName:version`. 
+
 ## Services
 
 Services add links into the primary container, exposing the services for utilization. For the most part, services utilize the same format for definition as the primary container.

--- a/src/index.js
+++ b/src/index.js
@@ -121,7 +121,7 @@ const instance = {
    */
   attachFrom: (cfg) => {
     if (!cfg.from) {
-      return images.getImage(cfg.dockerfile)
+      return images.getImage(cfg.dockerfile, cfg.tags || [])
         .then(imageId => {
           cfg.from = imageId
           return cfg

--- a/test/src/command.spec.js
+++ b/test/src/command.spec.js
@@ -77,11 +77,15 @@ describe('command', () => {
   })
   describe('get', () => {
     let processCwdStub
+    let oldIsTTY
     beforeEach(() => {
       processCwdStub = sinon.stub(process, 'cwd', () => '/tmp')
+      oldIsTTY = process.stdout.isTTY
+      process.stdout.isTTY = true
     })
     afterEach(() => {
       processCwdStub.restore()
+      process.stdout.isTTY = oldIsTTY
     })
     it('throws error if missing \'from\' property', () => {
       expect(() => command.get({})).to.throw('Missing \'from\' property in config or argument')

--- a/test/src/images.spec.js
+++ b/test/src/images.spec.js
@@ -82,14 +82,25 @@ describe('images', () => {
         args = a
         return Promise.resolve()
       })
-      return images.buildImage('./Foo', 'bar').then(() => {
+      return images.buildImage('./Foo', ['bar']).then(() => {
         expect(args[2]).to.equal('/tmp/Foo')
         expect(args[4]).to.equal('bar')
       })
     })
+    it('runs a build with multiple tags', () => {
+      let args
+      sandbox.stub(proc, 'run', (a) => {
+        args = a
+        return Promise.resolve()
+      })
+      return images.buildImage('./Foo', ['bar', 'baz', 'tek']).then(() => {
+        expect(args).to.deep.equal([ 'build', '-f', '/tmp/Foo',
+          '-t', 'bar', '-t', 'baz', '-t', 'tek', '/tmp' ])
+      })
+    })
     it('rejects when the command fails', () => {
       sandbox.stub(proc, 'run', () => Promise.reject(new Error('test rejection')))
-      return expect(images.buildImage('./Foo', 'bar')).to.be.rejected()
+      return expect(images.buildImage('./Foo', ['bar'])).to.be.rejected()
     })
   })
   describe('getImage', () => {
@@ -115,7 +126,7 @@ describe('images', () => {
       const spy = sandbox.stub(images, 'buildImage', (df, name) => Promise.resolve(name))
       return images.getImage('df').then(() => {
         expect(spy).to.be.calledOnce()
-        expect(spy).to.be.calledWith('df', 'tmp:bc_deadbeefbeef')
+        expect(spy).to.be.calledWith('df', ['tmp:bc_deadbeefbeef'])
       })
     })
     it('deletes an old image after a successful build', () => {

--- a/test/src/index.spec.js
+++ b/test/src/index.spec.js
@@ -150,6 +150,15 @@ describe('index', () => {
         expect(cfg).to.have.property('from').equal('deadbeef')
       })
     })
+    it('passes extra tags to the image build process', () => {
+      const conf = getConfig()
+      delete conf.from
+      conf.tags = ['foo', 'bar']
+      const stub = sandbox.stub(images, 'getImage', () => Promise.resolve('foo'))
+      return instance.attachFrom(conf).then(() => {
+        expect(stub).to.be.calledWith(undefined, ['foo', 'bar'])
+      })
+    })
   })
   describe('start', () => {
     it('calls checkForUpdates', () => {

--- a/test/src/index.spec.js
+++ b/test/src/index.spec.js
@@ -115,6 +115,14 @@ describe('index', () => {
     })
   })
   describe('getRunConfig', () => {
+    let oldIsTTY
+    before(() => {
+      oldIsTTY = process.stdout.isTTY
+      process.stdout.isTTY = true
+    })
+    after(() => {
+      process.stdout.isTTY = oldIsTTY
+    })
     it('loads config and args and returns exec run command objects', () => {
       const rmOnShutdown = false
       args.raw = { f: 'node:6', e: 'echo "foo"', _: [], c: configPath }


### PR DESCRIPTION
Adds a "tags" property to the binci.yml that can be used in conjunction with the recently added dockerfile functionality. When Binci builds a new container from a dockerfile, it can now optionally tag it with one or more additional tags.

The use case here is that, if building a container on CI, the user may want to push that container directly to deployment rather than rebuilding it again under a different tag. This saves a second build, or hacky code to search for the binci build to re-tag it.