### PR TITLE
feat(images): Support rebuild on other file changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,20 @@ The above binci.yml will, in the event that Binci needs to build a new container
 addition to the two listed tags. When Binci is done running, the command `docker push myorg/myrepo:latest` would work
 as expected.
 
+## Rebuilding
+
+When a `dockerfile` is used, Binci will automatically rebuild it if the `dockerfile` changes. However, it may be necessary to trigger a rebuild when other files change that may impact the build. To list these files, specify `rebuildOnChange`:
+
+```yaml
+dockerfile: ./Dockerfile
+rebuildOnChange:
+  - ./Gemfile
+  - ./Gemfile.lock
+  - ./Rakefile
+```
+
+When any of those files are changed, created, or deleted, the next Binci run will rebuild the image from the dockerfile before executing the task. 
+
 ## Services
 
 Services add links into the primary container, exposing the services for utilization. For the most part, services utilize the same format for definition as the primary container.

--- a/src/index.js
+++ b/src/index.js
@@ -121,7 +121,7 @@ const instance = {
    */
   attachFrom: (cfg) => {
     if (!cfg.from) {
-      return images.getImage(cfg.dockerfile, cfg.tags || [])
+      return images.getImage(cfg.dockerfile, cfg.rebuildOnChange, cfg.tags)
         .then(imageId => {
           cfg.from = imageId
           return cfg

--- a/test/src/images.spec.js
+++ b/test/src/images.spec.js
@@ -29,12 +29,17 @@ describe('images', () => {
   })
   describe('getHash', () => {
     it('determines the SHA-1 hash of an existing file', () => {
-      return images.getHash(knownShaPath).then(hash => {
+      return images.getHash([knownShaPath]).then(hash => {
         expect(hash).to.equal(knownSha.substr(0, 12))
       })
     })
+    it('determines the SHA-1 hash of multiple files', () => {
+      return images.getHash([knownShaPath, knownShaPath]).then(hash => {
+        expect(hash).to.equal('cdb39cef22e6')
+      })
+    })
     it('returns null if the file does not exist', () => {
-      return images.getHash(knownShaPath + 'notfound').then(hash => {
+      return images.getHash([knownShaPath + 'notfound']).then(hash => {
         expect(hash).to.be.null()
       })
     })

--- a/test/src/index.spec.js
+++ b/test/src/index.spec.js
@@ -164,7 +164,7 @@ describe('index', () => {
       conf.tags = ['foo', 'bar']
       const stub = sandbox.stub(images, 'getImage', () => Promise.resolve('foo'))
       return instance.attachFrom(conf).then(() => {
-        expect(stub).to.be.calledWith(undefined, ['foo', 'bar'])
+        expect(stub).to.be.calledWith(undefined, undefined, ['foo', 'bar'])
       })
     })
   })


### PR DESCRIPTION
Binci already rebuilds containers when the Dockerfile is changed (assuming we're not using `from`), however there are other changes one can make to a repo that would alter a built container without needing to modify the Dockerfile. For example, if a container is built with all the app's dependencies, and a dependency is added or changed in `package.json` or `Gemfile` or `requirements.txt` et. al., the next binci run would fail because the container would not be rebuilt with the new requirement. Worse, if a different engineer on the team does a `git pull`, binci tasks may start failing for him or her without them having any knowledge that dependencies were ever changed.

This PR adds a `rebuildOnChange` property to `binci.yml` that allows the user to list out paths to "monitor". This is not active monitoring -- Binci simply reads the contents of those files into the hash it was already building from the Dockerfile. If any of those files change, the hash will change and the image will be rebuilt before the task runs.