### PR TITLE
feat(relative-volumes): allows use of relative volumes from host

### DIFF
--- a/src/command.js
+++ b/src/command.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const _ = require('halcyon')
+const path = require('path')
 
 const command = {
   /**
@@ -23,12 +24,21 @@ const command = {
     return process.env.hasOwnProperty(envVar) ? process.env[envVar] : defaultValue
   }),
   /**
+   * Parses volumes to allow relative pathing from host mounts
+   * @param {Array} vols The volume array to parse
+   * @returns {Array}
+   */
+  parseVolumes: (vols) => vols.map((v) => v.startsWith('.') ? path.resolve(process.cwd(), v) : v),
+  /**
    * Reduces args array into flagged arguments list
    * @param {string} type Name of the argument
    * @param {array} args Array of values
    * @returns {array}
    */
-  parseArgs: (type, args) => _.chain((item) => ([command.args[type], command.parseHostEnvVars(item)]), args),
+  parseArgs: (type, args) => {
+    args = type === 'volumes' ? command.parseVolumes(args) : args
+    return _.chain((item) => ([command.args[type], command.parseHostEnvVars(item)]), args)
+  },
   /**
    * Parses config object and returns container name. Will have bc_ prefix and
    * InstanceID suffix if ephemeral, unaltered name for persisted containers

--- a/test/src/command.spec.js
+++ b/test/src/command.spec.js
@@ -17,9 +17,15 @@ describe('command', () => {
       expect(command.parseHostEnvVars('test-${BC_TEST_EV_DNE}')).to.equal('test-') // eslint-disable-line no-template-curly-in-string
     })
   })
+  describe('parseVolumes', () => {
+    it('returns volumes with correct pathing', () => {
+      expect(command.parseVolumes([ './foo:/bar', '/foo:/bar' ])).to.deep.equal([ `${process.cwd()}/foo:/bar`, '/foo:/bar' ])
+    })
+  })
   describe('parseArgs', () => {
     it('returns an array of a specific argument type and its values', () => {
       expect(command.parseArgs('expose', ['8080:8080', '9090:9090'])).to.deep.equal(['-p', '8080:8080', '-p', '9090:9090'])
+      expect(command.parseArgs('volumes', [ './foo:/bar' ])).to.deep.equal(['-v', `${process.cwd()}/foo:/bar`])
     })
   })
   describe('getName', () => {


### PR DESCRIPTION
This change will allow for mapping host volumes using relative pathing, for example, given working directory `/home/foo/app/`

```yaml
volumes:
  - ../foo:/foo
```

Where the above would map the equivalent of `-v /home/foo:/foo`