### PR TITLE
[FIX] Docker image generation fails if project directory has uppercase characters

### DIFF
--- a/src/command.js
+++ b/src/command.js
@@ -133,7 +133,7 @@ const command = {
       command.getArgs(cfg),
       command.getLinks(cfg),
       ['--name', command.getName(name, cfg)],
-      cfg.from,
+      cfg.from.toLowerCase(),
       primary ? ['sh', `${tmpdir}/binci.sh`] : []
     ]))
     return primary ? { args, cmd: command.getExec(cfg) } : args

--- a/src/images.js
+++ b/src/images.js
@@ -20,7 +20,7 @@ const images = {
   buildImage: (dockerfile, tags = []) => {
     output.info(`Building image from ${dockerfile}`)
     output.line()
-    const tagArgs = tags.reduce((acc, cur) => acc.concat(['-t', cur]), [])
+    const tagArgs = tags.reduce((acc, cur) => acc.concat(['-t', cur.toLowerCase()]), [])
     return proc.run([
       'build',
       '-f', path.resolve(process.cwd(), dockerfile)


### PR DESCRIPTION
Hi,
I've fixed a bug that causes binci to fail when using a custom Dockerfile while working in a project directory that contains upper case characters. Docker, in fact, doesn't allow upper case characters in the images name.
I've called the "toLowerCase()" function in order to "sanitize" images name when necessary.

Tests apart I haven't checked if there are other corner cases like that though.