### PR TITLE
Print missing local images before service start

### DIFF
--- a/src/images.js
+++ b/src/images.js
@@ -73,6 +73,29 @@ const images = {
     }))
   }),
   /**
+   * Searches for local images matching the names and tags defined in the service config
+   * and prints a courtesy message for whichever are not found saying they will pulled
+   * as part of service start-up.
+   * @param {Array<Object>} [svc=[]] The array of services defined in the instance config.
+   */
+  logMissingServiceImages: (svc = []) => Promise.resolve().then(() => {
+    if (!svc.length) return
+    const missingImages = svc.reduce((arr, i) => {
+      const cmd = [
+        'docker images',
+        '"--filter=reference=' + i.args[i.args.length - 1] + '"'
+      ].join(' ')
+      const out = cp.execSync(cmd).toString().split('\n')
+      if (!out[1]) {
+        arr.push(i.name)
+      }
+      return arr
+    }, [])
+    if (missingImages.length) {
+      output.info(`Unable to find local image${missingImages.length > 1 ? 's' : ''} for ${missingImages.join(', ')}. Pulling during start step.`)
+    }
+  }),
+  /**
    * Gets the SHA-1 checksum, truncated to 12 hexadecimal digits, of the combined contents of the
    * files at the paths provided.
    * @param {Array<string>} paths An array of paths for the files to include in the checksum

--- a/src/images.js
+++ b/src/images.js
@@ -76,10 +76,9 @@ const images = {
    * Searches for local images matching the names and tags defined in the service config
    * and prints a courtesy message for whichever are not found saying they will pulled
    * as part of service start-up.
-   * @param {Array<Object>} [svc=[]] The array of services defined in the instance config.
+   * @param {Array<Object>} svc The array of services defined in the instance config.
    */
-  logMissingServiceImages: (svc = []) => Promise.resolve().then(() => {
-    if (!svc.length) return
+  logMissingServiceImages: (svc) => Promise.resolve().then(() => {
     const missingImages = svc.reduce((arr, i) => {
       const cmd = [
         'docker images',

--- a/src/index.js
+++ b/src/index.js
@@ -64,20 +64,22 @@ const instance = {
   startServices: (cfg) => {
     // No services, resolve
     if (!cfg.services.length) return Promise.resolve(cfg)
-    // Start services
-    const svcNames = _.map(_.prop('name'), cfg.services).join(', ')
-    const servicesStartSpinner = output.spinner(`Starting service${cfg.services.length > 1 ? 's' : ''} ${svcNames}`)
-    return services.run(cfg.services)
-      .then(() => {
-        servicesStartSpinner.succeed()
-        return cfg
-      })
-      .catch((e) => {
-        servicesStartSpinner.fail()
-        const failed = e.svcs
-        /* istanbul ignore next */
-        throw new Error(`Failed to start service${failed.length > 1 ? 's' : ''}: ${failed.join(', ')}`)
-      })
+    return images.logMissingServiceImages(cfg.services).then(() => {
+      // Start services
+      const svcNames = _.map(_.prop('name'), cfg.services).join(', ')
+      const servicesStartSpinner = output.spinner(`Starting service${cfg.services.length > 1 ? 's' : ''} ${svcNames}`)
+      return services.run(cfg.services)
+        .then(() => {
+          servicesStartSpinner.succeed()
+          return cfg
+        })
+        .catch((e) => {
+          servicesStartSpinner.fail()
+          const failed = e.svcs
+          /* istanbul ignore next */
+          throw new Error(`Failed to start service${failed.length > 1 ? 's' : ''}: ${failed.join(', ')}`)
+        })
+    })
   },
   /**
    * Stops services and resolves or rejects

--- a/test/src/images.spec.js
+++ b/test/src/images.spec.js
@@ -67,6 +67,36 @@ describe('images', () => {
       })
     })
   })
+  describe('logMissingServiceImages', () => {
+    beforeEach(() => {
+      sandbox.stub(output, 'info')
+    })
+    it('logs message with missing service images', () => {
+      sandbox.stub(cp, 'execSync', () => ({ toString: () => (
+        'REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE'
+      )}))
+      const cfg = [{
+        name: 'node',
+        args: ['fake_node:latest']
+      }]
+      return images.logMissingServiceImages(cfg).then(() => {
+        expect(output.info).to.be.calledWith('Unable to find local image for node. Pulling during start step.')
+      })
+    })
+    it('logs nothing if local service images are found', () => {
+      sandbox.stub(cp, 'execSync', () => ({ toString: () => (
+        'REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE\n' +
+        'node                latest              f697cb5f31f8        12 months ago       675MB'
+      )}))
+      const cfg = [{
+        name: 'node',
+        args: ['node:latest']
+      }]
+      return images.logMissingServiceImages(cfg).then(() => {
+        expect(output.info).to.not.be.called()
+      })
+    })
+  })
   describe('deleteImage', () => {
     it('executes the delete command successfully', () => {
       let cmd

--- a/test/src/index.spec.js
+++ b/test/src/index.spec.js
@@ -33,6 +33,7 @@ describe('index', () => {
     sandbox.stub(output, 'success')
     sandbox.stub(output, 'warn')
     sandbox.stub(output, 'error')
+    sandbox.stub(images, 'logMissingServiceImages', () => Promise.resolve())
   })
   describe('checkForUpdates', () => {
     it('warns user if an update is available', () => {


### PR DESCRIPTION
More for consideration than anything, since this is pretty simplistic and doesn't exactly _fix_ #87 (and definitely not #99). Instead of intercepting and parsing Docker's output at runtime, this just preemptively checks if there are missing images, and prints a courtesy message letting the user know which will be pulled as part of start-up (implying some delay, which is what led to originally opening that issue).