### PR TITLE
Fix issue with Windows path being rejected by Docker for Windows

### DIFF
--- a/src/command.js
+++ b/src/command.js
@@ -3,6 +3,8 @@
 const _ = require('halcyon')
 const path = require('path')
 
+const dewindowize = require('./dewindowize')
+
 const command = {
   /**
    * @property {object} available args parsing instructions, matches config name
@@ -113,7 +115,7 @@ const command = {
    */
   get: (cfg, name, tmpdir, primary = false) => {
     if (!cfg.from) throw new Error('Missing \'from\' property in config or argument')
-    const cwd = process.cwd()
+    const cwd = dewindowize(process.cwd())
     const workDir = cfg.workDir || cwd
     let args
     if (primary) {

--- a/src/dewindowize.js
+++ b/src/dewindowize.js
@@ -1,0 +1,19 @@
+const path = require('path')
+const process = require('process')
+
+/**
+ * Method to convert a Windows path to a form that Docker accepts
+ * @param {string} (winPath) path to convert
+ * @returns {String} the converted path
+ */
+module.exports = (winPath) => {
+  console.log(process.platform)
+  console.log(path.isAbsolute(winPath))
+  console.log(winPath)
+
+  if (process.platform === 'win32' && path.isAbsolute(winPath)) {
+    return ('/' + winPath.replace(':', '').replace(new RegExp('\\\\', 'g'), '/'))
+  } else {
+    return winPath
+  }
+}

--- a/src/dewindowize.js
+++ b/src/dewindowize.js
@@ -7,10 +7,6 @@ const process = require('process')
  * @returns {String} the converted path
  */
 module.exports = (winPath) => {
-  console.log(process.platform)
-  console.log(path.isAbsolute(winPath))
-  console.log(winPath)
-
   if (process.platform === 'win32' && path.isAbsolute(winPath)) {
     return ('/' + winPath.replace(':', '').replace(new RegExp('\\\\', 'g'), '/'))
   } else {

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,8 @@ const images = require('./images')
 
 const tmpdir = require('./tempdir')()
 
+const dewindowize = require('./dewindowize')
+
 global.instanceId = require('shortid').generate()
 
 const instance = {
@@ -54,7 +56,7 @@ const instance = {
    */
   getRunConfig: (projConfig, rmOnShutdown) => ({
     services: services.get(projConfig),
-    primary: command.get(_.merge(projConfig, { rmOnShutdown }), 'primary', tmpdir, true)
+    primary: command.get(_.merge(projConfig, { rmOnShutdown }), 'primary', dewindowize(tmpdir), true)
   }),
   /**
    * Starts services and resolves or rejects


### PR DESCRIPTION
This fix will address issues #105 and #106 . 

The problem is that Docker expect Windows paths in the following format:

`/C/path/to/directory`

Here's an example error when we use the plain process.cwd() method:

```
PS C:\GitHub\node-openid-provider> binci test
√ Starting services vault, db
√ Running Task
‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧
docker: Error response from daemon: the working directory 'C:\GitHub\node-openid-provider' is invalid, it needs to be an absolute path.
See 'docker run --help'.
‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧‧
× Command failed
PS C:\GitHub\node-openid-provider>
```

The exact same issue applies to the tmpdir that is used to mount docker volumes. This fix still requires the use of BINCI_TMP env variable that's set to an absolute Windows path. 