### PR TITLE
feat(services): Add command property

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,10 @@ The `stopTimeSecs` above would forcibly stop the container after 3 seconds using
 
 In addition to setting the `stopTimeSecs` per service, this property can be set in the root of the `binci.yml` configuration and will be applied to any services that don't have an explicit `stopTimeSecs` property.
 
+## Service Command (`command <string|Array>`)
+
+In the event that a service's default command needs to be overridden, the `command` property can do that. Specify the command with a string or array of strings.
+
 ## Development
 
 ### Tests

--- a/src/command.js
+++ b/src/command.js
@@ -118,17 +118,20 @@ const command = {
     const cwd = dewindowize(process.cwd())
     const workDir = cfg.workDir || cwd
     let args
+    let cmd
     if (primary) {
       // Running the main project container
       args = ['run', '--rm', '-v', `${cwd}:${workDir}:cached`, '-v', `${tmpdir}:${tmpdir}`, '-w', workDir]
       if (cfg.privileged !== false) args.push('--privileged')
       /* istanbul ignore else */
       if (process.stdout.isTTY) args.push('-it')
+      cmd = ['sh', `${tmpdir}/binci.sh`]
     } else {
       // Running a service
       args = ['run', '-d']
       if (cfg.privileged !== false) args.push('--privileged')
       if (!cfg.rmOnShutdown) args.push('--rm')
+      cmd = cfg.command
     }
     // Has user config
     if (cfg.user) args.push(`--user=${command.parseHostEnvVars(cfg.user)}`)
@@ -138,7 +141,7 @@ const command = {
       command.getLinks(cfg),
       ['--name', command.getName(name, cfg)],
       cfg.from.toLowerCase(),
-      primary ? ['sh', `${tmpdir}/binci.sh`] : []
+      cmd || []
     ]))
     return primary ? { args, cmd: command.getExec(cfg) } : args
   }

--- a/test/fixtures/binci.yml
+++ b/test/fixtures/binci.yml
@@ -1,10 +1,11 @@
 from: mhart/alpine-node:6
-services: 
-  - mongodb: 
+services:
+  - mongodb:
       from: mongo:3.0
       expose:
         - 27017:27017
       persist: false
+      command: mongodb --arg
 expose:
   - 8080:8080
 tasks:

--- a/test/fixtures/instance.js
+++ b/test/fixtures/instance.js
@@ -14,7 +14,8 @@ const instance = {
           '27017:27017',
           '--name',
           'bc_mongodb_test',
-          'mongo:3.0'
+          'mongo:3.0',
+          'mongodb --arg'
         ]
       }
     ],
@@ -58,7 +59,8 @@ const instance = {
           '27017:27017',
           '--name',
           'bc_mongodb_test',
-          'mongo:3.0'
+          'mongo:3.0',
+          'mongodb --arg'
         ]
       }
     ],

--- a/test/src/services.spec.js
+++ b/test/src/services.spec.js
@@ -34,12 +34,12 @@ describe('services', () => {
     it('returns an array of services and their command arrays', () => {
       const svc = services.get(_.merge({ rmOnShutdown: false }, config.load()))
       expect(svc[0].name).to.equal('mongodb')
-      expect(svc[0].args).to.deep.equal(['run', '-d', '--privileged', '--rm', '-p', '27017:27017', '--name', 'bc_mongodb_test', 'mongo:3.0'])
+      expect(svc[0].args).to.deep.equal(['run', '-d', '--privileged', '--rm', '-p', '27017:27017', '--name', 'bc_mongodb_test', 'mongo:3.0', 'mongodb --arg'])
     })
     it('returns an array of services and their command arrays (with rmOnShutdown)', () => {
       const svc = services.get(_.merge({ rmOnShutdown: true }, config.load()))
       expect(svc[0].name).to.equal('mongodb')
-      expect(svc[0].args).to.deep.equal(['run', '-d', '--privileged', '-p', '27017:27017', '--name', 'bc_mongodb_test', 'mongo:3.0'])
+      expect(svc[0].args).to.deep.equal(['run', '-d', '--privileged', '-p', '27017:27017', '--name', 'bc_mongodb_test', 'mongo:3.0', 'mongodb --arg'])
     })
   })
   describe('run', () => {


### PR DESCRIPTION
So once upon a time two days ago I started using DynamoDB Local in my test stack. Amazon, in its endless campaign to make shit difficult, doesn't support customizing DDB local via env vars, only cli options. Which, in a docker container, means passing your own command string.

No big deal, I thought. Surely Kent and I thought of this already. Lemmie just check the Binci docs.

...nope, turns out we have zero way to tell services to use a different command for startup!

Now we do :). And suddenly DDB local works for me!